### PR TITLE
Update restrictKey to a function using filterWithKey 

### DIFF
--- a/src/Gossip/Caas.hs
+++ b/src/Gossip/Caas.hs
@@ -35,7 +35,7 @@ plusAgentWith (nRel,sRel) x nums =
 subGraphWith :: Graph -> [Agent] -> Graph
 subGraphWith (nRel,sRel) ys = (fix nRel, fix sRel) where
   subset = IntSet.fromList ys
-  fix r = IntMap.map (IntSet.intersection subset) $ IntMap.restrictKeys r subset
+  fix r = IntMap.map (IntSet.intersection subset) $ IntMap.filterWithKey (\k _ -> k `IntSet.member` subset) r
 
 isSubGraphOf :: Graph -> Graph -> Bool
 isSubGraphOf (nRelA,sRelA) (nRelB,sRelB) = (nRelA `isSubRelOf` nRelB) && (sRelA `isSubRelOf` sRelB)


### PR DESCRIPTION
When running `cabal build` on the project, cabal errors, giving us the error message:

    src/Gossip/Caas.hs:38:53: error:
        Not in scope: ‘IntMap.restrictKeys’
        Module ‘Data.IntMap’ does not export ‘restrictKeys’.

It seems that restrictKeys has been deprecated. However, we can use the helpful equality from [here](https://hackage.haskell.org/package/containers-0.5.10.2/docs/Data-Map-Strict.html#v:restrictKeys) to provide an easy way around this problem.

When this update is applied, all tests are passed when running `stack clean; stack test --coverage`. 